### PR TITLE
chore: pass fullStackAnalysis command trigger parameter over IPC connection

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -93,7 +93,8 @@ export function activate(context: vscode.ExtensionContext) {
           fileEvents: vscode.workspace.createFileSystemWatcher('**/.clientrc')
         },
         initializationOptions: {
-          crdaHost: apiConfig.crdaHost
+          crdaHost: apiConfig.crdaHost,
+          triggerFullStackAnalysis: Commands.TRIGGER_FULL_STACK_ANALYSIS
         },
       };
 


### PR DESCRIPTION
Bug description:
While each marked dependency presents a 'Detailed Vulnerability Report' option in the QuickFix section,
by clicking on the 'Detailed Vulnerability Report' option, no dependency report is rendered and instead an error is prompted explaining that the requested command cannot be found. 

Fix description:
The command trigger for the Full Stack Analysis CodeAction set up in the late LSP server has been hardcoded and no longer in use. 
As a solution, the new command trigger will be transferred from the LSP client to the LSP server via IPC initializationOptions and will no longer be hard coded in the LSP server, thus rendering the 'Detailed Vulnerability Report' as requested.